### PR TITLE
fix: Use new Content Type Parser function signature

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -152,8 +152,8 @@ const EikService = class EikService {
             // Handle multipart upload
             const _multipart = Symbol('multipart');
 
-            function setMultipart(req, cb) {
-                req[_multipart] = true;
+            function setMultipart(req, payload, cb) {
+                req.raw[_multipart] = true;
                 cb();
             }
             app.addContentTypeParser('multipart', setMultipart);


### PR DESCRIPTION
Use the new Content Type Parser function signature introduced in in Fastify 3. Eliminates the following warning on start of the server:

```sh
(node:211412) [FSTDEP003] FastifyDeprecation [FSTDEP003]: You are using the legacy Content Type Parser function signature. Use the one suggested in the documentation instead.
(Use `node --trace-warnings ...` to show where the warning was created)

```