### PR TITLE
feat: Set custom 404 handler

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -164,11 +164,19 @@ const EikService = class EikService {
                 global: config.get('compression.global'),
             });
 
+            // 404 handling
+            app.setNotFoundHandler((request, reply) => {
+                  reply.header('cache-control', 'no-store');
+                  reply.type('text/plain');
+                  reply.code(404);
+                  reply.send('Not found');
+            });
+
             // Error handling
             app.setErrorHandler((error, request, reply) => {
                 this.logger.debug('Error occured during request. Error is available on trace log level.');
                 this.logger.trace(error);
-
+                reply.header('cache-control', 'no-store');
                 if (error.statusCode) {
                     reply.send(error);
                     return;

--- a/test/404.js
+++ b/test/404.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const FormData = require('form-data');
+const fastify = require('fastify');
+const fetch = require('node-fetch');
+const tap = require('tap');
+
+const Server = require("..");
+const Sink = require('../node_modules/@eik/core/lib/sinks/test');
+
+tap.test('404 - POST request to non existing pathname', async (t) => {
+    const sink = new Sink();
+    const service = new Server({ customSink: sink });
+
+    const app = fastify({
+        ignoreTrailingSlash: true,
+    });
+    app.register(service.api());
+
+    const address = await app.listen(0, 'localhost');
+
+    const formData = new FormData();
+    formData.append('key', 'change_me');
+
+    const response = await fetch(`${address}/non/existent`, {
+        method: 'POST',
+        body: formData,
+        headers: formData.getHeaders(),
+    });
+  
+    t.equals(response.status, 404, 'server should respond with a 404 Not found');
+    t.equals(response.headers.get('cache-control'), 'no-store', 'should contain "cache-control" set to "no-store"');
+
+    await app.close();
+});
+
+tap.test('404 - GET request to non existing pathname', async (t) => {
+    const sink = new Sink();
+    const service = new Server({ customSink: sink });
+
+    const app = fastify({
+        ignoreTrailingSlash: true,
+    });
+    app.register(service.api());
+
+    const address = await app.listen(0, 'localhost');
+
+    const response = await fetch(`${address}/non/existent`);
+  
+    t.equals(response.status, 404, 'server should respond with a 404 Not found');
+    t.equals(response.headers.get('cache-control'), 'no-store', 'should contain "cache-control" set to "no-store"');
+
+    await app.close();
+});


### PR DESCRIPTION
Set a custom 404 error handler with a `Cache-Control` header set to `no-store`. This will prevent 404 requests to be stored in any http cache in front of the server.

Solves: https://github.com/eik-lib/core/issues/169