### PR TITLE
fix: Use yaml.load()

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -8,7 +8,7 @@ const fs = require('fs');
 const os = require('os');
 const pack = require('../package.json');
 
-convict.addParser({ extension: ['yml', 'yaml'], parse: yaml.safeLoad });
+convict.addParser({ extension: ['yml', 'yaml'], parse: yaml.load });
 
 convict.addFormat({
     name: 'secret-string',


### PR DESCRIPTION
Use `yaml.load()` over the removed `yaml.safeLoad()` method when loading yaml config.