### PR TITLE
fix: Make JWT expire time configurable

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -93,6 +93,12 @@ const conf = convict({
             env: 'AUTH_JWT_SECRET',
             sensitive: true,
         },
+        expire: {
+            doc: 'Expire time for JWT',
+            format: String,
+            default: '60d',
+            env: 'AUTH_JWT_EXPIRE',
+        },
     },
     basicAuth: {
         type: {

--- a/lib/main.js
+++ b/lib/main.js
@@ -197,7 +197,7 @@ const EikService = class EikService {
                 const body = JSON.parse(JSON.stringify(outgoing.body));
 
                 const token = app.jwt.sign(body, {
-                    expiresIn: '7d',
+                    expiresIn: config.get('jwt.expire'),
                 });
 
                 reply.header('cache-control', outgoing.cacheControl);


### PR DESCRIPTION
Make the JWT expire time configurable and also bump the default time to 60 days instead of 7.