### PR TITLE
fix: Make config be read from import folder

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,16 +1,15 @@
 import convict from 'convict';
 import yaml from 'js-yaml';
 import pino from 'pino';
-import path, { dirname, join } from 'path';
+import path, { join } from 'path';
 import fs from 'fs';
 import os from 'os';
-import { fileURLToPath } from 'url';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+const { pathname } = new URL("./", import.meta.url);
 
 let pack = {};
 try {
-    pack = JSON.parse(fs.readFileSync(join(__dirname, '../../package.json')));
+    pack = JSON.parse(fs.readFileSync(join(pathname, '../../../../package.json')));
 } catch (error) {
     /* empty */
 }
@@ -160,7 +159,7 @@ const logger = pino({
 });
 
 try {
-    conf.loadFile(path.join(__dirname, `../config/${env}.yaml`));
+    conf.loadFile(path.join(pathname, `../../../../config/${env}.yaml`));
 } catch (error) {
     logger.error(error);
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -5,11 +5,11 @@ import path, { join } from 'path';
 import fs from 'fs';
 import os from 'os';
 
-const { pathname } = new URL("./", import.meta.url);
+const PWD = process.cwd();
 
 let pack = {};
 try {
-    pack = JSON.parse(fs.readFileSync(join(pathname, '../../../../package.json')));
+    pack = JSON.parse(fs.readFileSync(join(PWD, 'package.json')));
 } catch (error) {
     /* empty */
 }
@@ -159,7 +159,7 @@ const logger = pino({
 });
 
 try {
-    conf.loadFile(path.join(pathname, `../../../../config/${env}.yaml`));
+    conf.loadFile(path.join(PWD, `/config/${env}.yaml`));
 } catch (error) {
     logger.error(error);
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -5,11 +5,11 @@ import path, { join } from 'path';
 import fs from 'fs';
 import os from 'os';
 
-const PWD = process.cwd();
+const CWD = process.cwd();
 
 let pack = {};
 try {
-    pack = JSON.parse(fs.readFileSync(join(PWD, 'package.json')));
+    pack = JSON.parse(fs.readFileSync(join(CWD, 'package.json')));
 } catch (error) {
     /* empty */
 }
@@ -159,7 +159,7 @@ const logger = pino({
 });
 
 try {
-    conf.loadFile(path.join(PWD, `/config/${env}.yaml`));
+    conf.loadFile(path.join(CWD, `/config/${env}.yaml`));
 } catch (error) {
     logger.error(error);
 }


### PR DESCRIPTION
This fixes that we get hold for the correct files in the project depending on this module and not files inside this module. How we resolve this changed when we moved this module from CommonJS to ESM.