### PR TITLE
fixing warning stemming from depreaction 

### DIFF
--- a/bin/eik-server.js
+++ b/bin/eik-server.js
@@ -20,4 +20,7 @@ try {
     // Do accept errors
 }
 
-await app.listen(eik.config.get('http.port'), eik.config.get('http.address'));
+await app.listen({
+    port: eik.config.get('http.port'),
+    host: eik.config.get('http.address')
+});


### PR DESCRIPTION
[fastify issue 3652](https://github.com/fastify/fastify/issues/3652) makes the Eik server start with a deprecation warning
```
(node:10132) [FSTDEP011] FastifyDeprecation: Variadic listen method is deprecated. Please use ".listen(optionsObject)" instead. The variadic signature will be removed in `fastify@5`.
```
This PR uses an options object in `.listen` to remove the annoying warning.