### PR TITLE
Fixing issue with default config not being sent to FileSystem sink

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -30,7 +30,7 @@ const EikService = class EikService {
             sink = new eik.sink.MEM();
         } else {
             logger.info(`Server is running with the file system sink. Uploaded files will be stored under "${config.get('sink.path')}"`);
-            sink = new eik.sink.FS();
+            sink = new eik.sink.FS({ sinkFsRootPath: config.get('sink.path') });
         }
 
         // Transform organization config


### PR DESCRIPTION
Closes https://github.com/eik-lib/service/issues/491

This PR resolves this issue by sending the the default from the service into the FileSystem sink.