### PR TITLE
fix - adding /ping for eik-client ping command

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -195,6 +195,11 @@ const EikService = class EikService {
             // Routes
             //
 
+            const pingRoute = async (request, reply) => {
+                reply.type('text/plain')
+                reply.code(200)
+                reply.send('pong')
+            }
             const authPostRoutes = async (request, reply) => {
                 const outgoing = await this._authPost.handler(
                     request.raw,
@@ -302,7 +307,6 @@ const EikService = class EikService {
                 reply.redirect(outgoing.location);
             };
 
-
             const aliasGetRoute = async (request, reply) => {
                 const params = utils.sanitizeParameters(request.raw.url);
                 const outgoing = await this._aliasGet.handler(
@@ -363,6 +367,7 @@ const EikService = class EikService {
                 reply.send(outgoing.body);
             };
 
+            app.get('/ping', pingRoute);
 
             //
             // Authentication
@@ -371,7 +376,6 @@ const EikService = class EikService {
             // curl -X POST -i -F key=foo http://localhost:4001/auth/login
 
             app.post(`/${eik.prop.base_auth}/login`, authPostRoutes);
-
 
             //
             // Packages

--- a/test/ping.js
+++ b/test/ping.js
@@ -1,0 +1,25 @@
+import Fastify from 'fastify';
+import tap from 'tap';
+import fetch from 'node-fetch'
+
+import Sink from "@eik/core/lib/sinks/test.js";
+import Server from '../lib/main.js';
+
+tap.test('ping - returns pong', async  t => {
+  const service = new Server({ customSink: new Sink() });
+
+  const app = Fastify({
+    ignoreTrailingSlash: true,
+  });
+  app.register(service.api());
+
+  const address = await app.listen({ port: 0, host: '127.0.0.1' });
+  const response = await fetch(`${address}/ping`, {
+    method: 'GET',
+  });
+  t.ok(response.ok)
+  t.equal(response.status, 200, 'returns 200 OK')
+  t.equal(await response.text(), 'pong')
+
+  await app.close()
+})


### PR DESCRIPTION
Adds a `/ping` route to be used by the [cli](../cli) ping command, which currently fails by default when running:
```
eik ping http://localhost:4100
```
the PR will enable changing this to `eik ping http://localhost:4100/ping` 