### PR TITLE
fix: let compression finish before adding routes

### DIFF
--- a/bin/eik-server.js
+++ b/bin/eik-server.js
@@ -12,7 +12,7 @@ const app = Fastify({
     http2: eik.config.get('http.http2'),
 });
 
-app.register(eik.api());
+await app.register(eik.api());
 
 try {
     await eik.health();

--- a/lib/main.js
+++ b/lib/main.js
@@ -201,7 +201,8 @@ const EikService = class EikService {
     }
 
     api() {
-        return (app, options, done) => {
+        /** @param {import('fastify').FastifyInstance} app */
+        return async (app) => {
             if (!app.initialConfig.ignoreTrailingSlash) {
                 this.logger.warn(
                     'Fastify is configured with "ignoreTrailingSlash" set to "false". Its adviced to set "ignoreTrailingSlash" to "true"',
@@ -233,6 +234,7 @@ const EikService = class EikService {
             });
 
             const authOptions = {
+                // @ts-expect-error We decorate it above
                 preValidation: [app.authenticate],
             };
 
@@ -246,7 +248,7 @@ const EikService = class EikService {
             app.addContentTypeParser('multipart', setMultipart);
 
             // Compression
-            app.register(compression, {
+            await app.register(compression, {
                 global: config.get('compression.global'),
             });
 
@@ -905,8 +907,6 @@ const EikService = class EikService {
                 authOptions,
                 aliasDelRoute,
             );
-
-            done();
         };
     }
 };

--- a/test/compression.test.js
+++ b/test/compression.test.js
@@ -1,0 +1,78 @@
+import FormData from 'form-data';
+import fastify from 'fastify';
+import fetch from 'node-fetch';
+import path from 'path';
+import tap from 'tap';
+import url from 'url';
+import fs from 'fs';
+
+import Sink from './utils/sink.js';
+import Server from '../lib/main.js';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+const FIXTURE_PKG = path.resolve(__dirname, '..', 'fixtures', 'archive.tgz');
+
+// Ignore the timestamp for "created" field in the snapshots
+tap.cleanSnapshot = (s) => {
+    const regex = /"created": [0-9]+,/gi;
+    return s.replace(regex, '"created": -1,');
+};
+
+/** @type {import('fastify').FastifyInstance} */
+let app;
+/** @type {string} */
+let address;
+/** @type {Record<string, string>} */
+let headers;
+/** @type {Sink} */
+let sink;
+
+tap.teardown(async () => {
+    sink.clear();
+    await app.close();
+});
+
+tap.test('compression - assets should have content-encoding: br', async (t) => {
+    sink = new Sink();
+    const service = new Server({ sink });
+
+    app = fastify({
+        ignoreTrailingSlash: true,
+        forceCloseConnections: true,
+    });
+
+    await app.register(service.api());
+
+    address = await app.listen({ port: 0, host: '127.0.0.1' });
+
+    let formData = new FormData();
+    formData.append('key', 'change_me');
+    let res = await fetch(`${address}/auth/login`, {
+        method: 'POST',
+        body: formData,
+        headers: formData.getHeaders(),
+    });
+    const login = /** @type {{ token: string }} */ (await res.json());
+    headers = { Authorization: `Bearer ${login.token}` };
+
+    formData = new FormData();
+    formData.append('package', fs.createReadStream(FIXTURE_PKG));
+
+    // PUT files on server
+    res = await fetch(`${address}/pkg/@cuz/fuzz/1.4.8`, {
+        method: 'PUT',
+        body: formData,
+        redirect: 'manual',
+        headers: { ...headers, ...formData.getHeaders() },
+    });
+    t.equal(res.status, 303, 'Expected to PUT OK');
+
+    res = await fetch(`${address}/pkg/@cuz/fuzz/1.4.8/main/index.js`, {
+        headers: {
+            'accept-encoding': 'br',
+        },
+    });
+    t.equal(res.status, 200, 'Expected to GET OK');
+    t.equal(res.headers.get('content-encoding'), 'br');
+});


### PR DESCRIPTION
BREAKING CHANGE: requires `await` when registering the eik plugin with fastify
(`await fastify.register(service.api())`).